### PR TITLE
Helper overhaul & RESTifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ How about a use case? Let's say your application allowed users to look up parts 
 
 DynamicSelectable makes the above easy to do by providing a generator for your dynamic `collection_select` along with a new `FormHelper` method called `dynamic_collection_select`.
 
+To see this gem in action, you can check out the sample application [here](https://github.com/mattantonelli/dynamic-selectable-test).
+
 ## Updating from 0.0.2
 
 ***Warning:*** *If you are updating from `0.0.2` you will need to re-generate any content created with* `rails generate dynamic_selectable:select`.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ How about a use case? Let's say your application allowed users to look up parts 
 
 DynamicSelectable makes the above easy to do by providing a generator for your dynamic `collection_select` along with a new `FormHelper` method called `dynamic_collection_select`.
 
+## Updating from 0.0.2
+
+***Warning:*** *If you are updating from `0.0.2` you will need to re-generate any content created with* `rails generate dynamic_selectable:select`.
+
 ## Installation
 
 Add the following line to your application's Gemfile:
@@ -22,7 +26,7 @@ Install the gem by running `bundle install`.
 
 Run the gem's install generator:
 
-```bash
+```
 $ rails generate dynamic_selectable:install
 ```
 
@@ -78,44 +82,36 @@ class Model < ActiveRecord::Base
 end
 ```
 
-To generate the controller and route necessary for your selection of `Make` to dynamically populate your selection of `Model`, you would run the following:
+To generate the controller and route necessary for your selection of `Make` to dynamically populate your selection of `Model`, run the following:
 
-```bash
+```
 # Usage: rails generate dynamic_selectable:select parent child value_method text_method [sort_col:asc/desc]
 $ rails generate dynamic_selectable:select make model id name name:asc
 ```
 
-Now you just need to build your form. The method `dynamic_collection_select` is very similar to `collection_select`, but contains some new parameters:
+Now you just need to build your form. The method `dynamic_collection_select` is very similar to [collection_select](http://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/collection_select), but contains the new `dynamic_model` parameter. This parameter is a symbol representing the child model whose collection will be populated based on the value selected in this parent field.
 
-<dl>
-  <dt>current</dt>
-  <dd>Symbol representing the class of the object being built in the current form</dd>
+If you would like to submit the value of the `dynamic_collection_select` with the form, just add `{ submit_with_form: true }` to the `options` hash.
 
-  <dt>select_parent</dt>
-  <dd>The parent field that will determine the population of the related child field</dd>
-
-  <dt>select_child</dt>
-  <dd>The child field that will be populated based on the selection in the parent field</dd>
-</dl>
 
 ```ruby
-def dynamic_collection_select(current, select_parent, select_child, collection,
-                              value_method, text_method, options, html_options)
+def dynamic_collection_select(object, method, dynamic_model, collection, value_method, text_method,
+                              options = {}, html_options = {})
 ```
 
 A very simple form would look something like this:
 
 ```html+erb
 <%= form_for(@vehicle) do |f| %>
-  <div class="form-group">
+  <div>
     <%= label_tag :make_id %>
     <%= dynamic_collection_select :vehicle, :make, :model, Make.all, :id, :name,
-        { include_blank: true }, { class: 'form-control' } %>
+        { include_blank: true }, {} %>
   </div>
 
-  <div class="form-group">
+  <div>
     <%= f.label :model_id %>
-    <%= f.collection_select :model_id, [], :id, :name, {}, { class: 'form-control' } %>
+    <%= f.collection_select :model_id, [], :id, :name, {}, {} %>
   </div>
 
   <%# ... %>
@@ -124,6 +120,53 @@ A very simple form would look something like this:
 
 That's it. Happy selecting!
 
+## Working with Ransack
+
+By default, DynamicSelectable uses the `object` and `method` parameters of `dynamic_collection_select` to generate data attributes used by the gem's Javascript. However, if you are creating a form for a gem like [Ransack](https://github.com/activerecord-hackery/ransack), the values you provide for these parameters could prevent DynamicSelectable from generating the necessary data attributes properly. To resolve this, you will need to manually specify these attributes in a `data` hash within your tag's `html_options` hash. For example:
+
+```html+erb
+<%= dynamic_collection_select :q, :make_id_eq, :model, Make.all, :id, :name,
+  {}, { data: { dynamic_selectable_url:    '/dynamic_selectable/makes/:make_id/models',
+                dynamic_selectable_target: '#q_model_id_eq' } } %>
+```
+
+The value for `dynamic_selectable_url` can be found in your routes:
+
+```
+$ rake routes | grep dynamic
+dynamic_selectable_make_models GET    /dynamic_selectable/makes/:make_id/models(.:format) dynamic_selectable/make_models#index
+```
+
+and the value for `dynamic_selectable_target` is generated with your form. This can be found by inspecting the child element in your web browser.
+
+## Removing generated content
+
+#### Remove a generated controller/route
+
+```
+$ rm app/controllers/dynamic_selectable/models_controller.rb
+```
+
+and remove the related line from your `routes.rb`:
+
+```ruby
+get ':make_id/models', to: 'models#index', as: :models
+```
+
+#### Complete uninstallation
+
+```bash
+$ rm -rf app/controllers/dynamic_selectable
+```
+
+and remove the following block from your `routes.rb`:
+
+```ruby
+namespace :dynamic_selectable do
+  # ...
+end
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/atni/dynamic_selectable/fork )
@@ -131,3 +174,4 @@ That's it. Happy selecting!
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+

--- a/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
+++ b/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
@@ -4,7 +4,7 @@ module DynamicSelectable
       module DynamicFormOptionsHelper
         def dynamic_collection_select(object, method, dynamic_model, collection, value_method, text_method,
                                       options = {}, html_options = {})
-          select_url    = "dynamic_selectable_#{dynamic_model.to_s.pluralize}_path"
+          select_url    = "dynamic_selectable_#{method.to_s.sub(/_id$/, '')}_#{dynamic_model.to_s.pluralize}_path"
           parent_id     = ":#{method}"
           select_target = "##{object}_#{dynamic_model}_id"
 

--- a/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
+++ b/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
@@ -11,7 +11,13 @@ module DynamicSelectable
           data_options = { data: { dynamic_selectable_url: send(select_url, parent_id),
                                    dynamic_selectable_target: select_target } }
 
-          collection_select(nil, nil, collection, value_method, text_method, options, html_options.merge(data_options))
+          if options[:submit_with_form] == true
+            submit_object = object
+            submit_method = method
+          end
+
+          collection_select(submit_object, submit_method, collection, value_method, text_method,
+                            options, html_options.merge(data_options))
         end
       end
     end

--- a/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
+++ b/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
@@ -11,6 +11,8 @@ module DynamicSelectable
           data_options = { data: { dynamic_selectable_url: send(select_url, parent_id),
                                    dynamic_selectable_target: select_target } }
 
+          data_options[:data].merge!(html_options.fetch(:data, {}))
+
           if options[:submit_with_form] == true
             submit_object = object
             submit_method = method

--- a/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
+++ b/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
@@ -2,11 +2,11 @@ module DynamicSelectable
   module ActionView
     module Helpers
       module DynamicFormOptionsHelper
-        def dynamic_collection_select(current, select_parent, select_child, collection, value_method, text_method,
-                                      options, html_options)
-          select_url    = "dynamic_selectable_#{select_child.to_s.pluralize}_path"
-          parent_id     = ":#{select_parent}_id"
-          select_target = "##{current}_#{select_child}_id"
+        def dynamic_collection_select(object, method, dynamic_model, collection, value_method, text_method,
+                                      options = {}, html_options = {})
+          select_url    = "dynamic_selectable_#{dynamic_model.to_s.pluralize}_path"
+          parent_id     = ":#{method}"
+          select_target = "##{object}_#{dynamic_model}_id"
 
           data_options = { data: { dynamic_selectable_url: send(select_url, parent_id),
                                    dynamic_selectable_target: select_target } }

--- a/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
+++ b/lib/dynamic_selectable/action_view/helpers/dynamic_form_options_helper.rb
@@ -8,10 +8,13 @@ module DynamicSelectable
           parent_id     = ":#{method}"
           select_target = "##{object}_#{dynamic_model}_id"
 
-          data_options = { data: { dynamic_selectable_url: send(select_url, parent_id),
-                                   dynamic_selectable_target: select_target } }
+          data = html_options.fetch(:data, {})
+          url, target = data.delete(:dynamic_selectable_url), data.delete(:dynamic_selectable_target)
 
-          data_options[:data].merge!(html_options.fetch(:data, {}))
+          data_options = { data: { dynamic_selectable_url:    url    || send(select_url, parent_id),
+                                   dynamic_selectable_target: target || select_target } }
+
+          data_options[:data].merge!(data)
 
           if options[:submit_with_form] == true
             submit_object = object

--- a/lib/dynamic_selectable/version.rb
+++ b/lib/dynamic_selectable/version.rb
@@ -1,3 +1,3 @@
 module DynamicSelectable
-  VERSION = "0.0.2"
+  VERSION = "1.0.0"
 end

--- a/lib/generators/dynamic_selectable/select_generator.rb
+++ b/lib/generators/dynamic_selectable/select_generator.rb
@@ -8,28 +8,29 @@ module DynamicSelectable
     end
 
     def create_controller_file
-      create_file controller_path(attributes.second), controller_body(*attributes)
+      create_file controller_path(*attributes.first(2)), controller_body(*attributes)
     end
 
     private
     def route(parent, child)
       children = child.pluralize
-      "    get ':#{parent}_id/#{children}', to: '#{children}#index', as: :#{children}\n"
+      "    get '#{parent.pluralize}/:#{parent}_id/#{children}', to: '#{parent}_#{children}#index', as: :#{parent}_#{children}\n"
     end
 
-    def controller_path(child)
-      "app/controllers/dynamic_selectable/#{child.pluralize.underscore}_controller.rb"
+    def controller_path(parent, child)
+      "app/controllers/dynamic_selectable/#{parent}_#{child.pluralize.underscore}_controller.rb"
     end
 
     def controller_body(parent, child, val, text, sort)
       children = child.pluralize
+      parent_class = parent.titleize.gsub(' ', '')
       select_class = children.titleize.gsub(' ', '')
-      child_class = child.titleize.gsub(' ', '')
+      child_class  = child.titleize.gsub(' ', '')
       order = sort.present? ? ".order('#{sort.gsub(':', ' ')}')" : ''
 
       <<-END
 module DynamicSelectable
-  class #{select_class}Controller < SelectController
+  class #{parent_class}#{select_class}Controller < SelectController
     def index
       #{children} = #{child_class}.where(#{parent}_id: params[:#{parent}_id]).select('#{val}, #{text}')#{order}
       render json: #{children}


### PR DESCRIPTION
##### Making the dynamic helper perform more naturally (27b15f5)
* More closely matches the format/behavior of the standard collection_select
  * `options` and `html_options` arguments now have default arguments of `{}`
    * Fixes bug where data options would fail to merge into a
      non-existent html_options hash
  * First two arguments are now `object` and `method`
* Resolves #7

##### Added an option to submit the dynamic parent (cd207f0)
* If the option `submit_with_form` is provided with a value of true,
  the dynamic parent will be submitted with the form
* Resolves #6
* Resolves #8

##### Made the generated routes more RESTful (a5214f3)
* Route information updated as follows:
  * dynamic_selectable_models → dynamic_selectable_make_models
  * /dynamic_selectable/:make_id/models → /dynamic_selectable/makes/:make_id/models
  * dynamic_selectable/models#index → dynamic_selectable/make_models#index
* Unfortunately, this will require all content generated using
  dynamic_selectable:select in prior versions to be regenerated

##### Allowing the user to specify the data options (8d612c7)
* Lets the user point to the dynamic selectable URL and target manually
* Also ensures any other user-specified data options are not overridden

##### Updated version (8b026ff)

##### Updated README.md (bf8fa49)

##### Added link to sample application (07732de)

##### Skipping URL calculation if custom URL is provided (48421c2)
* Prevents errors where an improper route helper would be called
